### PR TITLE
Add private route table and associate it with private subnet

### DIFF
--- a/projects/week1/vpc/vpc.yaml
+++ b/projects/week1/vpc/vpc.yaml
@@ -56,6 +56,22 @@ Resources:
         - Key: Name
           Value: !Sub /${Project}/PrivateSubnet
 
+  NetworkBootcampPrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref NetworkBootcampVPC
+      Tags:
+        - Key: Project
+          Value: !Ref Project
+        - Key: Name
+          Value: !Sub /${Project}/PrivateRouteTable
+  
+  NetworkBootcampPrivateRouteAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref NetworkBootcampPrivateSubnet
+      RouteTableId: !Ref NetworkBootcampPrivateRouteTable
+
   NetworkBootcampPublicSubnet:
     Type: AWS::EC2::Subnet
     Properties:
@@ -85,7 +101,7 @@ Resources:
         - Key: Project
           Value: !Ref Project
         - Key: Name
-          Value: !Sub /${Project}/RouteTable
+          Value: !Sub /${Project}/PublicRouteTable
   
   NetworkBootcampPublicRoute:
     Type: AWS::EC2::Route


### PR DESCRIPTION
Update because I noticed, rather than using the default route table, there is a separate route table created in the lecture.
File updated: `/projects/week1/vpc/vpc.yaml`